### PR TITLE
Cocktail versions (merged) + regular mra

### DIFF
--- a/releases/Atari Tetris (cocktail set 1).mra
+++ b/releases/Atari Tetris (cocktail set 1).mra
@@ -1,7 +1,7 @@
 <misterromdescription>
   <rbf>AtariTetris</rbf>
-<rom index="0" zip="atetrisc.zip" md5="41a700662430d190fb1ae1974770ad52">
-<part name="tetcktl1.rom"/>
-<part name="136066-1103.35a"/>
+<rom index="0" zip="atetris.zip" md5="41a700662430d190fb1ae1974770ad52">
+<part name="atetrisc/tetcktl1.rom"/>
+<part name="atetrisc/136066-1103.35a"/>
   </rom>
 </misterromdescription>

--- a/releases/Atari Tetris (cocktail set 2).mra
+++ b/releases/Atari Tetris (cocktail set 2).mra
@@ -1,7 +1,7 @@
-<misterromdescription>
+﻿<misterromdescription>
   <rbf>AtariTetris</rbf>
-<rom index="0" zip="atetrisc2.zip" md5="3363856fcc8e4fcbaaf5bceab01920e2">
-<part name="136066-1102.45f"/>
-<part name="136066-1103.35a"/>
+<rom index="0" zip="atetris.zip" md5="3363856fcc8e4fcbaaf5bceab01920e2">
+<part name="atetrisc2/136066-1102.45f"/>
+<part name="atetrisc/136066-1103.35a"/>
   </rom>
 </misterromdescription>

--- a/releases/Atari Tetris.mra
+++ b/releases/Atari Tetris.mra
@@ -1,0 +1,7 @@
+<misterromdescription>
+  <rbf>AtariTetris</rbf>
+<rom index="0" zip="atetris.zip" md5="a0c77ec919e7958798ce6ca999df4f85">
+<part name="136066-1100.45f"/>
+<part name="136066-1101.35a"/>
+  </rom>
+</misterromdescription>


### PR DESCRIPTION
better use merged mame roms.
also joined regular atari tetris version mra that was missing from release folder